### PR TITLE
Add an error class to be used when the server responds with a 504 Gateway Timeout error

### DIFF
--- a/lib/actv/error/gateway_timeout.rb
+++ b/lib/actv/error/gateway_timeout.rb
@@ -1,0 +1,11 @@
+require 'actv/error/server_error'
+
+module ACTV
+  class Error
+    # Raised when Active returns the HTTP status code 504
+    class GatewayTimeout < ACTV::Error::ServerError
+      HTTP_STATUS_CODE = 504
+      MESSAGE = 'Gateway Timeout'
+    end
+  end
+end

--- a/lib/actv/response/raise_server_error.rb
+++ b/lib/actv/response/raise_server_error.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'actv/error/bad_gateway'
+require 'actv/error/gateway_timeout'
 require 'actv/error/internal_server_error'
 require 'actv/error/service_unavailable'
 


### PR DESCRIPTION
I noticed requests when searching for events often returning a 504 status, which would cause the JSON parsing to choke on the returned HTML error page since there was no error class for a 504 status.