### PR TITLE
Add error to raise when server returns 596 Service Not Found

### DIFF
--- a/lib/actv/error/service_not_found.rb
+++ b/lib/actv/error/service_not_found.rb
@@ -1,0 +1,11 @@
+require 'actv/error/server_error'
+
+module ACTV
+  class Error
+    # Raised when Active returns the HTTP status code 596
+    class ServiceNotFound < ACTV::Error::ServerError
+      HTTP_STATUS_CODE = 596
+      MESSAGE = 'Service Not Found'
+    end
+  end
+end

--- a/lib/actv/response/raise_server_error.rb
+++ b/lib/actv/response/raise_server_error.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'actv/error/bad_gateway'
 require 'actv/error/internal_server_error'
+require 'actv/error/service_not_found'
 require 'actv/error/service_unavailable'
 
 module ACTV


### PR DESCRIPTION
I noticed requests when searching for events often returning a 596 status, which would cause the JSON parsing to choke on the returned HTML error page since there was no error class for a 596 status.