### PR TITLE
Depend on faraday 0.8.X as 0.9.0 breaks compatibility

### DIFF
--- a/actv.gemspec
+++ b/actv.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/actv/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.8'
+  gem.add_dependency 'faraday', '~> 0.8.0'
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'simple_oauth', '~> 0.1.6'
   gem.add_dependency 'nokogiri'
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'active_support'
 
-  
+
   gem.authors       = ["Nathaniel Barnes"]
   gem.email         = ["Nathaniel.Barnes@activenetwork.com"]
   gem.description   = %q{A Ruby wrapper for the Active API}


### PR DESCRIPTION
0.9.0 seems to have changed how open_timeout is handled, so running the
test suite with 0.9.0 raises the following error:

```
NoMethodError: undefined method `open_timeout=' for
#<Faraday::ConnectionOptions:0x007ff0220da470>
```