### PR TITLE
Adds Ability to Search by endurance_id

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -44,7 +44,10 @@ module ACTV
     alias required_gender regReqGenderCd
 
     def endurance_id
-      registrationUrlAdr.split('=').last if self.awendurance?
+      if self.awendurance?
+        query = URI(registrationUrlAdr).query
+        CGI::parse(query)["e"].first
+      end
     end
 
     def recurrences

--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -43,6 +43,10 @@ module ACTV
     alias maximum_age regReqMaxAge
     alias required_gender regReqGenderCd
 
+    def endurance_id
+      registrationUrlAdr.split('=').last if self.awendurance?
+    end
+
     def recurrences
       @recurrences ||= Array(@attrs[:activityRecurrences]).map do | recurrence |
         ACTV::Recurrence.new(recurrence)

--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -45,8 +45,7 @@ module ACTV
 
     def endurance_id
       if self.awendurance?
-        query = URI(registrationUrlAdr).query
-        CGI::parse(query)["e"].first
+        Addressable::URI.parse(registrationUrlAdr).query_values.fetch "e", nil
       end
     end
 

--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -126,7 +126,7 @@ module ACTV
     def find_by_endurance_id endurance_id
       response = get "/v2/search.json", find_by_endurance_id_params(endurance_id)
       ACTV::SearchResults.from_response(response).results.select do |asset|
-        registrationUrlAdr.end_with?("#{endurance_id}") and assetParentAsset[:assetGuid].nil?
+        asset.registrationUrlAdr.end_with?("#{endurance_id}") and asset.assetParentAsset[:assetGuid].nil?
       end
     end
 

--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -123,14 +123,11 @@ module ACTV
       ACTV::Asset.from_response(response)
     end
 
-    AWE_LEGACY_GUID = 'DFAA997A-D591-44CA-9FB7-BF4A4C8984F1'
     def find_by_endurance_id endurance_id
-      params = {
-        'asset.registrationUrlAdr' => endurance_id,
-        'asset.sourceSystem.legacyGuid' => AWE_LEGACY_GUID
-      }
-      response = get("/v2/search.json", params)
-      ACTV::SearchResults.from_response(response).results
+      response = get "/v2/search.json", find_by_endurance_id_params(endurance_id)
+      ACTV::SearchResults.from_response(response).results.select do |asset|
+        registrationUrlAdr.end_with?("#{endurance_id}") and assetParentAsset[:assetGuid].nil?
+      end
     end
 
     # Returns articles that match a specified query.
@@ -376,7 +373,15 @@ module ACTV
       credentials.values.all?
     end
 
-  private
+    private
+
+    def find_by_endurance_id_params endurance_id
+      awe_legacy_guid = 'DFAA997A-D591-44CA-9FB7-BF4A4C8984F1'
+      params = {
+        'asset.registrationUrlAdr' => "#{endurance_id}",
+        'asset.sourceSystem.legacyGuid' => awe_legacy_guid
+      }
+    end
 
     # Credentials hash
     #

--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -126,7 +126,7 @@ module ACTV
     def find_by_endurance_id endurance_id
       response = get "/v2/search.json", find_by_endurance_id_params(endurance_id)
       ACTV::SearchResults.from_response(response).results.select do |asset|
-        asset.registrationUrlAdr.end_with?("#{endurance_id}") and asset.assetParentAsset[:assetGuid].nil?
+        asset.registrationUrlAdr.end_with?(endurance_id.to_s) and asset.assetParentAsset[:assetGuid].nil?
       end
     end
 
@@ -378,7 +378,7 @@ module ACTV
     def find_by_endurance_id_params endurance_id
       awe_legacy_guid = 'DFAA997A-D591-44CA-9FB7-BF4A4C8984F1'
       params = {
-        'asset.registrationUrlAdr' => "#{endurance_id}",
+        'asset.registrationUrlAdr' => endurance_id.to_s,
         'asset.sourceSystem.legacyGuid' => awe_legacy_guid
       }
     end

--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -123,6 +123,16 @@ module ACTV
       ACTV::Asset.from_response(response)
     end
 
+    AWE_LEGACY_GUID = 'DFAA997A-D591-44CA-9FB7-BF4A4C8984F1'
+    def find_by_endurance_id endurance_id
+      params = {
+        'asset.registrationUrlAdr' => endurance_id,
+        'asset.sourceSystem.legacyGuid' => AWE_LEGACY_GUID
+      }
+      response = get("/v2/search.json", params)
+      ACTV::SearchResults.from_response(response).results
+    end
+
     # Returns articles that match a specified query.
     #
     # @authentication_required No

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/spec/actv/asset_spec.rb
+++ b/spec/actv/asset_spec.rb
@@ -3,6 +3,27 @@ require 'pry'
 
 describe ACTV::Asset do
 
+  describe '#endurance_id' do
+    let(:endurance_id) { 'endurance id' }
+    subject(:asset) { ACTV::Asset.new assetGuid: 'asset guid' }
+
+    context 'when asset is awe' do
+      before do
+        allow(asset).to receive(:registrationUrlAdr).and_return "https://endurancecui-vip.qa.aw.dev.activenetwork.com/event-reg/select-race?e=#{endurance_id}"
+        allow(asset).to receive(:awendurance?).and_return true
+      end
+      it 'returns the endurance id' do
+        expect(asset.endurance_id).to eq endurance_id
+      end
+    end
+    context 'when asset is not awe' do
+      before { allow(asset).to receive(:awendurance?).and_return false }
+      it 'is nil' do
+        expect(asset.endurance_id).to be_nil
+      end
+    end
+  end
+
   describe "#==" do
     it "return true when objects IDs are the same" do
       asset = ACTV::Asset.new(assetGuid: 1, assetName: "Title 1")

--- a/spec/actv/asset_spec.rb
+++ b/spec/actv/asset_spec.rb
@@ -4,8 +4,8 @@ require 'pry'
 describe ACTV::Asset do
 
   describe '#endurance_id' do
-    let(:endurance_id) { 'endurance id' }
-    subject(:asset) { ACTV::Asset.new assetGuid: 'asset guid' }
+    let(:endurance_id) { 'enduranceid' }
+    subject(:asset) { ACTV::Asset.new assetGuid: 'assetguid' }
 
     context 'when asset is awe' do
       before do

--- a/spec/actv/client_spec.rb
+++ b/spec/actv/client_spec.rb
@@ -124,10 +124,10 @@ describe ACTV::Client do
   describe "#credentials?" do
     it "returns true if all credentials are present" do
       client = ACTV::Client.new(consumer_key: 'CK', consumer_secret: 'CS', oauth_token: 'OT', oauth_token_secret: 'OS')
-      expect(client.credentials?).to be_truthy
+      expect(client.credentials?).to be_true
     end
     it "returns false if any credentials are missing" do
-      expect(client.credentials?).to be_falsey
+      expect(client.credentials?).to be_false
     end
   end
 


### PR DESCRIPTION
_this PR does the following_

* adds the method `find_by_endurance_id`
* adds tests for the new method
* updates old tests in the `client_spec.rb` file
* adds endurance_id method to asset_id
* adds tests for the method

_The new method `find_by_endurance_id` works like so_

```ruby

# Tries to match the registrationUrlAdr
# Which usually look like this: "https://endurancecui-vip.qa.aw.dev.activenetwork.com/event-reg/select-race?e=7534252"
# Searches by the endurance_id which is the e variable in the URL, called the endurance_id in ACL
# Only returns matches for Endurance events

ACTV.find_by_endurance_id 7534252
#=> [ACTV::Asset]

ACTV.find_by_endurance_id unknown_stuff
#=> []

# Adds ability to return endurance_id from the found asset
ACTV.asset("really-long-asset-id").first.endurance_id
#=> "7534252"

ACTV.asset("non-awe-asset-id").first.endurance_id
#=> nil
```