### PR TITLE
bulletproofs ACTV::Asset#endurance_id method

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -45,7 +45,7 @@ module ACTV
 
     def endurance_id
       if self.awendurance?
-        Addressable::URI.parse(registrationUrlAdr).query_values.fetch "e", nil
+        Addressable::URI.parse(registrationUrlAdr.to_s).query_values.to_h.fetch 'e', nil
       end
     end
 

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.3.3"
+  VERSION = "1.3.2"
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
allows handling of urls that are `nil` and `""`