### PR TITLE
A3-1647 ACM Article Preview

### DIFF
--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -157,9 +157,9 @@ module ACTV
       is_preview, params = params_include_preview? params
       request_string = '/preview' if is_preview
 
-      response = get("#{request_string}.json", params)
+      response = get "#{request_string}.json", params
 
-      article = ACTV::Article.from_response(response)
+      article = ACTV::Article.from_response response
       article.is_article? ? article : nil
     end
 

--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -152,8 +152,13 @@ module ACTV
     # @param options [Hash] A customizable set of options.
     # @example Return the article with the id BA288960-2718-4B20-B380-8F939596B123
     #   ACTV.article("BA288960-2718-4B20-B380-8F939596B123")
-    def article(id)
-      response = get("/v2/assets/#{id}.json")
+    def article id, params={}
+      request_string = "/v2/assets/#{id}"
+      is_preview, params = params_include_preview? params
+      request_string = '/preview' if is_preview
+
+      response = get("#{request_string}.json", params)
+
       article = ACTV::Article.from_response(response)
       article.is_article? ? article : nil
     end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.3.8"
+  VERSION = "1.3.9"
 end

--- a/spec/actv/client_spec.rb
+++ b/spec/actv/client_spec.rb
@@ -157,6 +157,50 @@ describe ACTV::Client do
     end
   end
 
+  describe '#article' do
+    let(:configuration) do
+      { consumer_key: "CK",
+        consumer_secret: "CS",
+        oauth_token: "OT",
+        oauth_token_secret: "OS"}
+    end
+
+    context 'find event' do
+      before do
+        stub_request(:get, "http://api.amp.active.com/v2/assets/asset_id.json").
+          to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
+      end
+
+      it 'makes a normal asset call' do
+        expect(client.article 'asset_id').to be_an ACTV::Article
+      end
+    end
+
+    context 'preview event' do
+      context 'when preview is true' do
+        before do
+          stub_request(:get, "http://api.amp.active.com/preview.json").
+            to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
+        end
+
+        it 'returns an event' do
+          expect(client.article 'asset_id', preview: 'true').to be_an ACTV::Article
+        end
+      end
+
+      context 'when preview is false' do
+        before do
+          stub_request(:get, "http://api.amp.active.com/v2/assets/asset_id.json").
+            to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
+        end
+
+        it 'returns an event' do
+          expect(client.article 'asset_id', preview: 'false').to be_an ACTV::Article
+        end
+      end
+    end
+  end
+
   describe '#event' do
     let(:configuration) do
       { consumer_key: "CK",


### PR DESCRIPTION
For starters, do you even seattle style bro?

Now onto business, this update adds the params argument to the article method and looks for the preview param. If the preview param is true, "/preview" is used as the request url. Thus A3 will render a preview page for the ACM.