### PR TITLE
A3 1647 acm article preview

### DIFF
--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -155,7 +155,7 @@ module ACTV
     def article id, params={}
       request_string = "/v2/assets/#{id}"
       is_preview, params = params_include_preview? params
-      request_string = '/preview' if is_preview
+      request_string += '/preview' if is_preview
 
       response = get "#{request_string}.json", params
 

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.3.9"
+  VERSION = "1.3.10"
 end

--- a/spec/actv/client_spec.rb
+++ b/spec/actv/client_spec.rb
@@ -165,7 +165,7 @@ describe ACTV::Client do
         oauth_token_secret: "OS"}
     end
 
-    context 'find event' do
+    context 'find article' do
       before do
         stub_request(:get, "http://api.amp.active.com/v2/assets/asset_id.json").
           to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
@@ -176,14 +176,14 @@ describe ACTV::Client do
       end
     end
 
-    context 'preview event' do
+    context 'preview article' do
       context 'when preview is true' do
         before do
           stub_request(:get, "http://api.amp.active.com/preview.json").
             to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
         end
 
-        it 'returns an event' do
+        it 'returns an article' do
           expect(client.article 'asset_id', preview: 'true').to be_an ACTV::Article
         end
       end
@@ -194,7 +194,7 @@ describe ACTV::Client do
             to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
         end
 
-        it 'returns an event' do
+        it 'returns an article' do
           expect(client.article 'asset_id', preview: 'false').to be_an ACTV::Article
         end
       end

--- a/spec/actv/client_spec.rb
+++ b/spec/actv/client_spec.rb
@@ -179,7 +179,7 @@ describe ACTV::Client do
     context 'preview article' do
       context 'when preview is true' do
         before do
-          stub_request(:get, "http://api.amp.active.com/preview.json").
+          stub_request(:get, "http://api.amp.active.com/v2/assets/asset_id/preview.json").
             to_return(body: fixture("valid_article.json"), headers: { content_type: "application/json; charset=utf-8" })
         end
 


### PR DESCRIPTION
This PR does three things:

1. Concatenates `/preview` to `request_string` if the `preview` param is set instead of setting it
2. Properly names specs in client_spec
3. Bump dat version!

![mario-bump](https://cloud.githubusercontent.com/assets/4232036/7540387/3a480cc2-f573-11e4-859b-8d56ac706d13.gif)
