### PR TITLE
A3 1643 asset references

### DIFF
--- a/lib/actv/client.rb
+++ b/lib/actv/client.rb
@@ -60,6 +60,7 @@ module ACTV
     alias search assets
 
     def asset id, params={}
+      params = params.with_indifferent_access
       is_preview = params.delete(:preview) == "true"
       response = request_response id, params, is_preview
       asset_from_response response

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
Some consumers, such as A3, of ACTV send in the params hash with symbol or string keys. 
We need to keep this support until we release a new major version of ACTV.