### PR TITLE
Author photo nil check

### DIFF
--- a/lib/actv/author.rb
+++ b/lib/actv/author.rb
@@ -29,8 +29,10 @@ module ACTV
     def photo
       @photo ||= begin
         image_node = from_footer 'div.signature-block-photo img'
-        url = image_node.attribute('src').to_s
-        ACTV::AssetImage.new imageUrlAdr: url
+        if image_node
+          url = image_node.attribute('src').to_s
+          ACTV::AssetImage.new imageUrlAdr: url
+        end
       end
     end
 

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "1.4.2"
+  VERSION = "1.4.3"
 end

--- a/spec/actv/author_spec.rb
+++ b/spec/actv/author_spec.rb
@@ -32,6 +32,18 @@ describe ACTV::Author do
     end
   end
 
+  describe '#photo' do
+    context 'when the footer has an image' do
+      its(:photo) { should be_a ACTV::AssetImage }
+    end
+    context 'when the footer does not have an image' do
+      before do
+        allow(author).to receive(:from_footer).with("div.signature-block-photo img").and_return nil
+      end
+      its(:photo) { should be_nil }
+    end
+  end
+
   describe '#image_url' do
     context 'when photo url is a fully qualified url' do
       it 'returns the photo url' do


### PR DESCRIPTION
We noticed an error rate in new relic during our release today, some assets do not contain a photo in their footer description. We were not handling this case in ACTV, I added a nil check and covered it with a test.