### PR TITLE
ACOM-751 add youtube videos to ED pages

### DIFF
--- a/lib/actv/asset_image.rb
+++ b/lib/actv/asset_image.rb
@@ -9,7 +9,7 @@ module ACTV
     alias link    linkUrl
     alias target  linkTarget
 
-    def is_video?
+    def video?
       target == "VIDEO" || type == "VIDEO"
     end
   end

--- a/lib/actv/asset_image.rb
+++ b/lib/actv/asset_image.rb
@@ -1,11 +1,16 @@
 module ACTV
   class AssetImage < Base
-    attr_reader :imageUrlAdr, :imageName, :imageCaptionTxt, :linkUrl, :linkTarget
+    attr_reader :imageUrlAdr, :imageName, :imageType, :imageCaptionTxt, :linkUrl, :linkTarget
 
     alias url     imageUrlAdr
     alias name    imageName
+    alias type    imageType
     alias caption imageCaptionTxt
     alias link    linkUrl
     alias target  linkTarget
+
+    def is_video?
+      target == "VIDEO" || type == "VIDEO"
+    end
   end
 end

--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -148,7 +148,7 @@ module ACTV
     end
 
     def video
-      self.images.detect { |i| i.is_video? }
+      self.images.detect { |i| i.video? }
     end
 
     alias online_registration? online_registration_available?

--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -147,6 +147,10 @@ module ACTV
       true
     end
 
+    def video
+      self.images.detect { |i| i.is_video? }
+    end
+
     alias online_registration? online_registration_available?
     alias reg_open? registration_open?
     alias reg_closed? registration_closed?
@@ -212,5 +216,3 @@ module ACTV
     end
   end
 end
-
-

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.0.1"
+  VERSION = "2.0.0"
 end

--- a/spec/actv/asset_image_spec.rb
+++ b/spec/actv/asset_image_spec.rb
@@ -1,27 +1,47 @@
 require 'spec_helper'
 
 describe ACTV::AssetImage do
-
-  before(:each) do
-    @img = ACTV::AssetImage.new(imageUrlAdr: 'http://test.com/1.jpg', 
-      imageName: 'image1', imageCaptionTxt: 'caption1', linkUrl: 'http://test.com/',
-      linkTarget: '_blank')
-  end
+  let(:imageType) { 'IMAGE' }
+  let(:linkTarget) { '_blank' }
+  subject(:img) { ACTV::AssetImage.new(imageUrlAdr: 'http://test.com/1.jpg',
+    imageName: 'image1', imageType: imageType, imageCaptionTxt: 'caption1', linkUrl: 'http://test.com/',
+    linkTarget: linkTarget) }
 
   describe "attribute accessors and aliases" do
-    subject { @img }
-
     its(:url){ should eq 'http://test.com/1.jpg' }
     its(:name){ should eq 'image1' }
+    its(:type){ should eq 'IMAGE' }
     its(:caption){ should eq 'caption1' }
     its(:link){ should eq 'http://test.com/'}
     its(:target){ should eq '_blank' }
-
     its(:imageUrlAdr){ should eq 'http://test.com/1.jpg' }
     its(:imageName){ should eq 'image1' }
+    its(:imageType){ should eq 'IMAGE' }
     its(:imageCaptionTxt){ should eq 'caption1' }
     its(:linkUrl){ should eq 'http://test.com/'}
     its(:linkTarget){ should eq '_blank' }
+  end
+
+  describe "#video?" do
+    context "when neither imageType nor linkTarget are video" do
+      it "knows it's not a video AssetImage" do
+        expect(subject.video?).to be_false
+      end
+    end
+
+    context "when imageType is video" do
+      let(:imageType) { 'VIDEO' }
+      it "knows it's a video AssetImage" do
+        expect(subject.video?).to be_true
+      end
+    end
+
+    context "when linkTarget is video" do
+      let(:linkTarget) { 'VIDEO' }
+      it "knows it's a video AssetImage" do
+        expect(subject.video?).to be_true
+      end
+    end
   end
 
 end

--- a/spec/actv/asset_image_spec.rb
+++ b/spec/actv/asset_image_spec.rb
@@ -3,9 +3,14 @@ require 'spec_helper'
 describe ACTV::AssetImage do
   let(:imageType) { 'IMAGE' }
   let(:linkTarget) { '_blank' }
-  subject(:img) { ACTV::AssetImage.new(imageUrlAdr: 'http://test.com/1.jpg',
-    imageName: 'image1', imageType: imageType, imageCaptionTxt: 'caption1', linkUrl: 'http://test.com/',
-    linkTarget: linkTarget) }
+  subject(:img) { ACTV::AssetImage.new({
+    imageUrlAdr: 'http://test.com/1.jpg',
+    imageName: 'image1',
+    imageType: imageType,
+    imageCaptionTxt: 'caption1',
+    linkUrl: 'http://test.com/',
+    linkTarget: linkTarget
+    }) }
 
   describe "attribute accessors and aliases" do
     its(:url){ should eq 'http://test.com/1.jpg' }

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -356,33 +356,25 @@ describe ACTV::Event do
       it 'returns the video AssetImage' do
         subject.video.should eq image1
       end
-    end
 
-    context 'when the event has more than one video AssetImage' do
+      context 'when the event has more than one video AssetImage' do
 
-      let(:image1) { ACTV::AssetImage.new({
-        imageUrlAdr: 'http://test.com/1.jpg',
-        imageName: 'image1',
-        imageType: 'VIDEO',
-        imageCaptionTxt: 'caption1',
-        linkUrl: 'http://test.com/',
-        linkTarget: 'VIDEO'
-        }) }
-      let(:image2) { ACTV::AssetImage.new({
-        imageUrlAdr: 'http://test.com/2.jpg',
-        imageName: 'image2',
-        imageType: 'VIDEO',
-        imageCaptionTxt: 'caption2',
-        linkUrl: 'http://test.com/',
-        linkTarget: 'VIDEO'
-        }) }
-        
-      before do
-        allow(subject).to receive(:images).and_return([image1, image2])
-      end
+        let(:image2) { ACTV::AssetImage.new({
+          imageUrlAdr: 'http://test.com/2.jpg',
+          imageName: 'image2',
+          imageType: 'VIDEO',
+          imageCaptionTxt: 'caption2',
+          linkUrl: 'http://test.com/',
+          linkTarget: 'VIDEO'
+          }) }
 
-      it 'returns the first video AssetImage' do
-        subject.video.should eq image1
+        before do
+          allow(subject).to receive(:images).and_return([image1, image2])
+        end
+
+        it 'returns the first video AssetImage' do
+          subject.video.should eq image1
+        end
       end
     end
 

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -336,4 +336,60 @@ describe ACTV::Event do
       end
     end
   end
+
+  describe '#video' do
+    context 'when the event has a video AssetImage' do
+
+      let(:image1) { ACTV::AssetImage.new({
+        imageUrlAdr: 'http://test.com/1.jpg',
+        imageName: 'image1',
+        imageType: 'VIDEO',
+        imageCaptionTxt: 'caption1',
+        linkUrl: 'http://test.com/',
+        linkTarget: 'VIDEO'
+        }) }
+
+      before do
+        allow(subject).to receive(:images).and_return([image1])
+      end
+
+      it 'returns the video AssetImage' do
+        subject.video.should eq image1
+      end
+    end
+
+    context 'when the event has more than one video AssetImage' do
+
+      let(:image1) { ACTV::AssetImage.new({
+        imageUrlAdr: 'http://test.com/1.jpg',
+        imageName: 'image1',
+        imageType: 'VIDEO',
+        imageCaptionTxt: 'caption1',
+        linkUrl: 'http://test.com/',
+        linkTarget: 'VIDEO'
+        }) }
+      let(:image2) { ACTV::AssetImage.new({
+        imageUrlAdr: 'http://test.com/2.jpg',
+        imageName: 'image2',
+        imageType: 'VIDEO',
+        imageCaptionTxt: 'caption2',
+        linkUrl: 'http://test.com/',
+        linkTarget: 'VIDEO'
+        }) }
+        
+      before do
+        allow(subject).to receive(:images).and_return([image1, image2])
+      end
+
+      it 'returns the first video AssetImage' do
+        subject.video.should eq image1
+      end
+    end
+
+    context 'when the event has no video AssetImage' do
+      it 'returns nil' do
+        subject.video.should be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
* add support for AS `imageType` field, and video attached to asset
* AWE / UX / UI have specified only a single video on the ED page (for now)