### PR TITLE
Faraday::Builder has been renamed to Faraday::RackBuilder

### DIFF
--- a/lib/actv/default.rb
+++ b/lib/actv/default.rb
@@ -49,7 +49,7 @@ module ACTV
       # @see https://github.com/technoweenie/faraday#advanced-middleware-usage
       # @see http://mislav.uniqpath.com/2011/07/faraday-advanced-http/
       def middleware
-        @middleware ||= Faraday::Builder.new(
+        @middleware ||= Faraday::RackBuilder.new(
           &Proc.new do |builder|
             builder.use ACTV::Request::MultipartWithFile # Convert file uploads to Faraday::UploadIO objects
             builder.use Faraday::Request::Multipart         # Checks for files in the payload


### PR DESCRIPTION
Get rid of the warning in A3 (and other ACTV using projects) due to the
rename.