### PR TITLE
ACOM-771 Memorize  quiz component assets

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -382,15 +382,12 @@ module ACTV
     private
 
     def child_assets_filtered_by_category category
-      child_assets.select { |child| child.category_is? category }
+      @children ||= Array(child_assets).compact
+      @children.select { |child| child.category_is? category }
     end
 
     def child_assets
-      @child_assets ||= begin
-        if components.any?
-          ACTV.asset components.map(&:assetGuid)
-        end || []
-      end
+      ACTV.asset components.map(&:assetGuid) if components.any?
     end
 
     def image_without_placeholder

--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -382,10 +382,15 @@ module ACTV
     private
 
     def child_assets_filtered_by_category category
-      if components.any?
-        children = ACTV.asset components.map(&:assetGuid)
-        children.select { |child| child.category_is? category }
-      end || []
+      child_assets.select { |child| child.category_is? category }
+    end
+
+    def child_assets
+      @child_assets ||= begin
+        if components.any?
+          ACTV.asset components.map(&:assetGuid)
+        end || []
+      end
     end
 
     def image_without_placeholder

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
When call `questions` and `outcomes` on a Quiz object, it requests same asset ids twice which should be memorized.