### PR TITLE
Update actv for quizzes

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -382,12 +382,15 @@ module ACTV
     private
 
     def child_assets_filtered_by_category category
-      @children ||= Array(child_assets).compact
-      @children.select { |child| child.category_is? category }
+      child_assets.select { |child| child.category_is? category }
     end
 
     def child_assets
-      ACTV.asset components.map(&:assetGuid) if components.any?
+      @child_assets ||= if components.any?
+                          ACTV.asset components.map(&:assetGuid)
+                        else
+                          []
+                        end
     end
 
     def image_without_placeholder

--- a/lib/actv/quiz.rb
+++ b/lib/actv/quiz.rb
@@ -11,5 +11,11 @@ module ACTV
     def outcomes
       @outcomes ||= child_assets_filtered_by_category 'outcome'
     end
+
+    def find_outcome_by_id guid
+      outcomes.find do |outcome|
+        outcome.assetGuid == guid
+      end
+    end
   end
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.2"
+  VERSION = "2.2.0"
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.1.1"
+  VERSION = "2.2"
 end

--- a/spec/actv/quiz_spec.rb
+++ b/spec/actv/quiz_spec.rb
@@ -48,4 +48,22 @@ describe ACTV::Quiz do
       it { should be_empty }
     end
   end
+
+  describe '#find_outcome_by_id' do
+    subject(:outcome) { quiz.find_outcome_by_id "123" }
+
+    context 'when the outcome exists' do
+      it 'returns an outcome' do
+        outcome_a = double(:outcome_a, assetGuid: "123")
+        outcome_b = double(:outcome_b, assetGuid: "234")
+        outcomes = [outcome_a, outcome_b]
+        allow(quiz).to receive(:outcomes) { outcomes }
+
+        expect(outcome).to eq outcome_a
+      end
+    end
+    context 'when the outcome does not exist' do
+      it { should be_nil }
+    end
+  end
 end


### PR DESCRIPTION
I added #find_outcome_by_id to the Quiz class and added specs. This allows you to search a specific quizzes possible outcomes by guid and return that single object.

I also memoized #child_assets in Asset and changed the logic around a little so that we are memoizing in one place and not two.