### PR TITLE
Guard against no organization

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -379,6 +379,10 @@ module ACTV
       end
     end
 
+    def organization
+      @attrs[:organization] || {}
+    end
+
     private
 
     def child_assets_filtered_by_category category

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/spec/actv/asset_spec.rb
+++ b/spec/actv/asset_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 describe ACTV::Asset do
 
+  describe '#organization' do
+    subject(:asset) { ACTV::Asset.new assetGuid: 'assetguid' }
+
+    context "when there is an organization field" do
+      before do
+        allow(asset).to receive(:organization).and_return({org: "test"})
+      end
+      its(:organization) { should eq({org: "test"}) }
+    end
+    context "where there is no organization field" do
+      its(:organization) { should eq({}) }
+    end
+  end
+
   describe '#endurance_id' do
     let(:endurance_id) { 'enduranceid' }
     subject(:asset) { ACTV::Asset.new assetGuid: 'assetguid' }


### PR DESCRIPTION
ANet started publishing assets without an organization field which causes errors on A3. This patch returns an empty hash if there is no organization field.