### PR TITLE
Add media type to asset validator

### DIFF
--- a/lib/actv/validators/asset_validator.rb
+++ b/lib/actv/validators/asset_validator.rb
@@ -12,6 +12,16 @@ module ACTV
 
     private
 
+    def asset_media_types
+      response[:assetMediaTypes] || []
+    end
+
+    def media_type_is? name
+      asset_media_types.any? do |media_type|
+        media_type[:mediaType][:mediaTypeName].downcase == name.downcase
+      end
+    end
+
     def asset_categories
       response[:assetCategories] || []
     end

--- a/lib/actv/validators/event_validator.rb
+++ b/lib/actv/validators/event_validator.rb
@@ -2,7 +2,7 @@ require 'actv/validators/asset_validator'
 module ACTV
   class EventValidator < AssetValidator
     def valid?
-      category_is?('event') || taxonomy_has?('event')
+      category_is?('event') || taxonomy_has?('event') || media_type_is?('event')
     end
   end
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end


### PR DESCRIPTION
Some source systems are labelling their asset as en event using the assetMedaTypes field. This change supports that field and adds the the matcher to the EventValidator.