### PR TITLE
Activecom 1021 p1 ccm activecom listing incorrect

### DIFF
--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -99,19 +99,19 @@ module ACTV
     # Returns the asset's registration open date
     # in UTC.  This is pulled from the salesStartDate
     def registration_open_date
-      Time.parse "#{authoritative_reg_start_date} UTC"
+      Time.parse parse_date_with_correct_time_zone(authoritative_reg_start_date)
     end
 
     # Returns the asset's registration end date
     # in UTC.  This is pulled from the salesEndDate
     def registration_close_date
-      Time.parse "#{authoritative_reg_end_date} UTC"
+      Time.parse parse_date_with_correct_time_zone(authoritative_reg_end_date)
     end
 
     # Returns the asset's start date
     # in UTC.  This is pulled from the activityStartDate.
     def event_start_date
-      Time.parse "#{activity_start_date} #{format_timezone_offset(timezone_offset)}"
+      Time.parse "#{activity_start_date} #{format_timezone_offset(place.timezoneOffset)}"
     end
 
     # Returns the asset's end date
@@ -160,6 +160,14 @@ module ACTV
     alias ended? event_ended?
 
     private
+
+    def parse_date_with_correct_time_zone date
+      if self.awcamps30? || self.awcamps? || self.regcenter2? || self.regcenter?
+        "#{date} #{format_timezone_offset(place.timezoneOffset)}"
+      else
+        "#{date} UTC"
+      end
+    end
 
     # EG: -7 => "-0700"
     def format_timezone_offset(offset)

--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -105,13 +105,14 @@ module ACTV
     # Returns the asset's registration end date
     # in UTC.  This is pulled from the salesEndDate
     def registration_close_date
+      puts parse_date_with_correct_time_zone(authoritative_reg_end_date)
       Time.parse parse_date_with_correct_time_zone(authoritative_reg_end_date)
     end
 
     # Returns the asset's start date
     # in UTC.  This is pulled from the activityStartDate.
     def event_start_date
-      Time.parse "#{activity_start_date} #{format_timezone_offset(place.timezoneOffset)}"
+      Time.parse "#{activity_start_date} #{format_timezone_offset(timezone_offset)}"
     end
 
     # Returns the asset's end date

--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -99,14 +99,13 @@ module ACTV
     # Returns the asset's registration open date
     # in UTC.  This is pulled from the salesStartDate
     def registration_open_date
-      Time.parse parse_date_with_correct_time_zone(authoritative_reg_start_date)
+      Time.parse parse_date_with_correct_timezone_or_offset(authoritative_reg_start_date)
     end
 
     # Returns the asset's registration end date
     # in UTC.  This is pulled from the salesEndDate
     def registration_close_date
-      puts parse_date_with_correct_time_zone(authoritative_reg_end_date)
-      Time.parse parse_date_with_correct_time_zone(authoritative_reg_end_date)
+      Time.parse parse_date_with_correct_timezone_or_offset(authoritative_reg_end_date)
     end
 
     # Returns the asset's start date
@@ -162,7 +161,7 @@ module ACTV
 
     private
 
-    def parse_date_with_correct_time_zone date
+    def parse_date_with_correct_timezone_or_offset date
       if self.awcamps30? || self.awcamps? || self.regcenter2? || self.regcenter?
         "#{date} #{format_timezone_offset(place.timezoneOffset)}"
       else

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -115,21 +115,21 @@ describe ACTV::Event do
 
   describe '#event_start_date' do
     before do
-      subject.stub(:activity_start_date).and_return("2013-05-10T00:00:00")
+      subject.stub(:activity_start_date).and_return('2013-05-10T00:00:00')
       subject.stub(:timezone_offset).and_return(-4)
     end
-    it "returns the correct date in the correct timezone" do
-      subject.event_start_date.should eq Time.parse "2013-05-10T00:00:00 -0400"
+    it 'returns the correct date in the correct timezone' do
+      subject.event_start_date.should eq Time.parse '2013-05-10T00:00:00 -0400'
     end
   end
 
   describe '#event_end_date' do
     before do
-      subject.stub(:activity_end_date).and_return("2013-05-10T00:00:00")
+      subject.stub(:activity_end_date).and_return('2013-05-10T00:00:00')
       subject.stub(:timezone_offset).and_return(-4)
     end
-    it "returns the correct date in the correct timezone" do
-      subject.event_end_date.should eq Time.parse "2013-05-10T00:00:00 -0400"
+    it 'returns the correct date in the correct timezone' do
+      subject.event_end_date.should eq Time.parse '2013-05-10T00:00:00 -0400'
     end
   end
 

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -85,12 +85,12 @@ describe ACTV::Event do
 
   describe '#registration_open_date' do
     before { subject.stub(:sales_start_date).and_return "2016-11-10T00:00:00" }
-      it "returns the correct date in correct timezone when asset belongs to camps or regcenter" do
+      it 'returns the correct date with correct timezone offset when asset belongs to camps or regcenter' do
         expect(subject.registration_open_date).to eq '2016-11-10T00:00:00 -0500'
       end
     context 'when asset not belongs to camps or regcenter' do
       before { subject.stub(:sourceSystem).and_return :legacyGuid => 'testid' }
-      it "returns the correct date in utc timezone" do
+      it 'returns the correct date in utc timezone' do
         expect(subject.registration_open_date).to eq '2016-11-10T00:00:00 UTC'
       end
     end
@@ -100,14 +100,14 @@ describe ACTV::Event do
     before { subject.stub(:sales_end_date).and_return '2016-12-10T00:00:00' }
     context 'when asset belongs to camps or regcenter' do
       before { subject.stub(:awcamps?).and_return true }
-      it "returns the correct date in the correct timezone" do
+      it 'returns the correct date with the correct timezone offset' do
         expect(subject.registration_close_date).to eq '2016-12-10T00:00:00 -0500'
       end
     end
 
     context 'when asset not belongs to camps or regcenter' do
       before { subject.stub(:sourceSystem).and_return :legacyGuid => 'testid' }
-      it "returns the correct date in utc timezone" do
+      it 'returns the correct date in utc timezone' do
         expect(subject.registration_close_date).to eq '2016-12-10T00:00:00 UTC'
       end
     end

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -84,16 +84,32 @@ describe ACTV::Event do
   end
 
   describe '#registration_open_date' do
-    before { subject.stub(:sales_start_date).and_return format_date 1.day.from_now }
-    it "returns the correct date in the correct timezone" do
-      subject.registration_open_date.should be_within(1.second).of Time.parse format_date_in_utc 1.day.from_now
+    before { subject.stub(:sales_start_date).and_return "2016-11-10T00:00:00" }
+      it "returns the correct date in correct timezone when asset belongs to camps or regcenter" do
+        expect(subject.registration_open_date).to eq '2016-11-10T00:00:00 -0500'
+      end
+    context 'when asset not belongs to camps or regcenter' do
+      before { subject.stub(:sourceSystem).and_return :legacyGuid => 'testid' }
+      it "returns the correct date in utc timezone" do
+        expect(subject.registration_open_date).to eq '2016-11-10T00:00:00 UTC'
+      end
     end
   end
 
   describe '#registration_close_date' do
-    before { subject.stub(:sales_end_date).and_return format_date 1.day.from_now }
-    it "returns the correct date in the correct timezone" do
-      subject.registration_close_date.should be_within(1.second).of Time.parse format_date_in_utc 1.day.from_now
+    before { subject.stub(:sales_end_date).and_return '2016-12-10T00:00:00' }
+    context 'when asset belongs to camps or regcenter' do
+      before { subject.stub(:awcamps?).and_return true }
+      it "returns the correct date in the correct timezone" do
+        expect(subject.registration_close_date).to eq '2016-12-10T00:00:00 -0500'
+      end
+    end
+
+    context 'when asset not belongs to camps or regcenter' do
+      before { subject.stub(:sourceSystem).and_return :legacyGuid => 'testid' }
+      it "returns the correct date in utc timezone" do
+        expect(subject.registration_close_date).to eq '2016-12-10T00:00:00 UTC'
+      end
     end
   end
 

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -84,7 +84,7 @@ describe ACTV::Event do
   end
 
   describe '#registration_open_date' do
-    before { subject.stub(:sales_start_date).and_return "2016-11-10T00:00:00" }
+    before { subject.stub(:sales_start_date).and_return '2016-11-10T00:00:00' }
       it 'returns the correct date with correct timezone offset when asset belongs to camps or regcenter' do
         expect(subject.registration_open_date).to eq '2016-11-10T00:00:00 -0500'
       end


### PR DESCRIPTION
#### JIRA
https://jirafnd.dev.activenetwork.com/browse/ACTIVECOM-1021

#### Description
Agency Name: Mitch Korn's Specialized Hockey Camps Inc.
CCM Database URL: https://camps.active.com/MitchKornsSpecializedHockeyCampsInc
Problem/Error message: Active.com search result is showing incorrect registration open time. Showing 3am. Should be 8am.
Steps to replicate:
1. www.Active.com > http://www.active.com/estero-fl/camps/mitch-korn-s-specialized-hockey-camps-inc-2016
Visual: Screenshots attached
Impact: The client is reporting the map is to his home and wants removed immediately.
Troubleshooting/Notes: No troubleshooting done

#### Solution

if the source system is `regcenter` or `camps` will parse the `sales_start_date` and `sales_end_date` with timezone rather than convert the timezone to 'utc'

#### TestLink
http://a3coreint10.dev.activenetwork.com/estero-fl/camps/mitch-korn-s-specialized-hockey-camps-inc-2016

**Note**
No code need changes by A3 side. However, we need to bump the version of `actv` in A3 Gemfile once the PR be merged to master.
Here is the branch for test on A3 side: https://github.com/activenetwork/a3/compare/ACTIVECOM-1021-P1-CCM-ACTIVECOM-Listing-incorrect