### PR TITLE
ACTIVECOM-1128 Fix nil exception when calculate timezone_offset if timezoneDST is nil

### DIFF
--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -121,7 +121,7 @@ module ACTV
     end
 
     def timezone_offset
-      place.timezoneOffset + place.timezoneDST
+      place.timezoneOffset + place.timezoneDST.to_i
     end
 
     def image_url

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.7.0"
+  VERSION = "2.7.1"
 end


### PR DESCRIPTION
https://jirafnd.dev.activenetwork.com/browse/ACTIVECOM-1128

When place.timezoneDST is nil will cause exception