### PR TITLE
ACOM 5086 Add recommended articles module

### DIFF
--- a/lib/actv/article.rb
+++ b/lib/actv/article.rb
@@ -45,6 +45,11 @@ module ACTV
       true
     end
 
+    def reference_articles
+      article_references = references.select { |ref| ref.type.downcase == 'reference-article' }
+      @reference_articles ||= ACTV.asset(article_references.map(&:id)) if article_references
+    end
+
     private
 
     def resolve_inline_ad_tag

--- a/lib/actv/article.rb
+++ b/lib/actv/article.rb
@@ -28,6 +28,10 @@ module ACTV
       @image ||= image_by_name 'image2'
     end
 
+    def thumbnail
+      @thumbnail ||= image_by_name 'small'
+    end
+
     def subtitle
       @subtitle ||= description_by_type 'subtitle'
     end

--- a/lib/actv/article.rb
+++ b/lib/actv/article.rb
@@ -47,7 +47,9 @@ module ACTV
 
     def reference_articles
       article_references = references.select { |ref| ref.type.downcase == 'reference-article' }
-      @reference_articles ||= ACTV.asset(article_references.map(&:id)) if article_references
+      if article_references.present?
+        @reference_articles ||= ACTV.asset(article_references.map(&:id))
+      end
     end
 
     private

--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -346,6 +346,10 @@ module ACTV
       @attrs[:organization] || {}
     end
 
+    def thumbnail
+      @thumbnail ||= image_by_name 'small'
+    end
+
     private
 
     def child_assets_filtered_by_category category

--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -346,10 +346,6 @@ module ACTV
       @attrs[:organization] || {}
     end
 
-    def thumbnail
-      @thumbnail ||= image_by_name 'small'
-    end
-
     private
 
     def child_assets_filtered_by_category category

--- a/lib/actv/asset_image.rb
+++ b/lib/actv/asset_image.rb
@@ -12,5 +12,13 @@ module ACTV
     def video?
       target == "VIDEO" || type == "VIDEO"
     end
+
+    def to_str
+      imageUrlAdr
+    end
+
+    def to_s
+      imageUrlAdr
+    end
   end
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.7.0"
+  VERSION = "2.8.0"
 end

--- a/spec/actv/article_spec.rb
+++ b/spec/actv/article_spec.rb
@@ -76,6 +76,21 @@ describe ACTV::Article do
     end
   end
 
+  describe '#thumbnail' do
+    context 'when article has an image named small' do
+      let(:asset_images) { [ { imageName: "small" } ] }
+      it 'returns the image' do
+        expect(article.thumbnail).to be_a ACTV::AssetImage
+      end
+    end
+
+    context 'when article does not have an image named small' do
+      it 'returns nil' do
+        expect(article.thumbnail).to be_nil
+      end
+    end
+  end
+
   describe '#subtitle' do
     context 'when a subtitle description exists' do
       its(:subtitle) { should eq "article subtitle" }
@@ -151,4 +166,16 @@ describe ACTV::Article do
       its(:author_name_from_by_line) { should be_nil }
     end
   end
+
+  describe '#reference_articles' do
+    let(:asset_references) { [ { referenceAsset: { assetGuid: "123" },
+                                  referenceType: { referenceTypeName: "reference-article" } } ] }
+    let(:article_asset) { double :article, id: "123" }
+    before { allow(ACTV).to receive(:asset) { [article_asset] } }
+
+    it 'returns reference articles if exist' do
+      expect(article.reference_articles.first.id).to eq article_asset.id
+    end
+  end
+
 end


### PR DESCRIPTION
Story:
https://jirafnd.dev.activenetwork.com/browse/ACOM-5086

Purpose:
+ Add `Article#reference_articles` to fetch reference articles
+ Add `Article#thumbnail` to fetch asset image with name `small`
+ Add `AssetImage#to_str` to make it be `imageUrlAdr ` while behaving like a string