### PR TITLE
Use error messages returned from a3pi

### DIFF
--- a/actv.gemspec
+++ b/actv.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'yard'
-  gem.add_development_dependency 'guard-rspec'
+  # gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'activesupport'
 
 

--- a/actv.gemspec
+++ b/actv.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'yard'
-  # gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'activesupport'
 
 

--- a/lib/actv/default.rb
+++ b/lib/actv/default.rb
@@ -55,8 +55,8 @@ module ACTV
             builder.use Faraday::Request::Multipart         # Checks for files in the payload
             builder.use Faraday::Request::UrlEncoded        # Convert request params as "www-form-urlencoded"
             builder.use ACTV::Response::RaiseClientError # Handle 4xx server responses
-            builder.use ACTV::Response::ParseJson        # Parse JSON response bodies using MultiJson
             builder.use ACTV::Response::RaiseServerError # Handle 5xx server responses
+            builder.use ACTV::Response::ParseJson        # Parse JSON response bodies using MultiJson
             # builder.use ACTV::Response::RateLimit        # Update RateLimit object
             builder.adapter Faraday.default_adapter         # Set Faraday's HTTP adapter
           end

--- a/lib/actv/response/raise_server_error.rb
+++ b/lib/actv/response/raise_server_error.rb
@@ -9,9 +9,12 @@ module ACTV
 
       def on_complete(env)
         status_code = env[:status].to_i
-        error_message = JSON.parse(env[:body])["error"]["message"]
         error_class = ACTV::Error::ServerError.errors[status_code]
-        raise error_class.new(error_message) if error_class
+
+        if error_class
+          error_message = JSON.parse(env[:body])["error"]["message"]
+          raise error_class.new(error_message)
+        end 
       end
 
     end

--- a/lib/actv/response/raise_server_error.rb
+++ b/lib/actv/response/raise_server_error.rb
@@ -12,7 +12,7 @@ module ACTV
         error_class = ACTV::Error::ServerError.errors[status_code]
 
         if error_class
-          error_message = JSON.parse(env[:body])["error"]["message"]
+          error_message = env[:body][:error][:message]
           raise error_class.new(error_message)
         end 
       end

--- a/lib/actv/response/raise_server_error.rb
+++ b/lib/actv/response/raise_server_error.rb
@@ -9,8 +9,9 @@ module ACTV
 
       def on_complete(env)
         status_code = env[:status].to_i
+        error_message = JSON.parse(env[:body])["error"]["message"]
         error_class = ACTV::Error::ServerError.errors[status_code]
-        raise error_class.new if error_class
+        raise error_class.new(error_message) if error_class
       end
 
     end


### PR DESCRIPTION
This, in conjuction with [this](https://gitlab.dev.activenetwork.com/activenetwork/a3pi/merge_requests/2) should allow us to get accurate error reporting from ACTV and A3PI.  The days of "Something is technically wrong" are no more.  We can now parse JSON error messages from A3PI and have ACTV forward them.