### PR TITLE
Remove guard as development dep

### DIFF
--- a/actv.gemspec
+++ b/actv.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'yard'
-  gem.add_development_dependency 'guard-rspec'
+  # gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'activesupport'
 
 

--- a/actv.gemspec
+++ b/actv.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'yard'
-  # gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'activesupport'
 
 


### PR DESCRIPTION
Guard / Listen removed support for ruby < 2.2, causing travis ci failures