### PR TITLE
Fix int do not match with string after esupgrade

### DIFF
--- a/lib/actv/asset.rb
+++ b/lib/actv/asset.rb
@@ -214,7 +214,7 @@ module ACTV
     end
 
     def evergreen?
-      self.evergreenAssetFlag.downcase == 'true' rescue false
+      self.evergreenAssetFlag.to_s.downcase == 'true' rescue false
     end
 
     def kids?

--- a/lib/actv/asset_status.rb
+++ b/lib/actv/asset_status.rb
@@ -14,7 +14,7 @@ module ACTV
     alias updated_at modifiedDate
 
     def visible?
-      id == 2
+      id.to_s == '2'
     end
   end
 end

--- a/lib/actv/asset_status.rb
+++ b/lib/actv/asset_status.rb
@@ -14,7 +14,7 @@ module ACTV
     alias updated_at modifiedDate
 
     def visible?
-      id == '2'
+      id == 2
     end
   end
 end

--- a/lib/actv/event.rb
+++ b/lib/actv/event.rb
@@ -84,12 +84,9 @@ module ACTV
 
     def display_close_date
       @display_close_date ||= begin
-        val = tag_by_description 'displayclosedate'
-        if val
-          val.downcase == 'true'
-        else
-          true
-        end
+        val = tag_by_description('displayclosedate')
+
+        val.nil? ? true : val.to_s.downcase == 'true'
       end
     end
     alias display_close_date? display_close_date

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.9.1"
+  VERSION = "2.9.2"
 end

--- a/lib/actv/version.rb
+++ b/lib/actv/version.rb
@@ -1,3 +1,3 @@
 module ACTV
-  VERSION = "2.9.0"
+  VERSION = "2.9.1"
 end

--- a/spec/actv/asset_spec.rb
+++ b/spec/actv/asset_spec.rb
@@ -547,4 +547,53 @@ describe ACTV::Asset do
       end
     end
   end
+
+  describe '#evergreenAssetFlag?' do
+    let(:response) { {assetGuid: 1} }
+    let(:asset) { ACTV::Asset.new response }
+
+    shared_examples 'asset#evergreen? with true value' do
+      it 'returns true' do
+        expect(asset.evergreen?).to eq true
+      end
+    end
+
+    shared_examples 'asset#evergreen? with false value' do
+      it 'returns true' do
+        expect(asset.evergreen?).to eq false
+      end
+    end
+
+    context 'when evergreenAssetFlag is boolean true' do
+      before { allow(asset).to receive(:evergreenAssetFlag) { true } }
+
+      it_behaves_like 'asset#evergreen? with true value'
+    end
+
+    context "when evergreenAssetFlag is string 'true'" do
+      before { allow(asset).to receive(:evergreenAssetFlag) { true } }
+
+      it_behaves_like 'asset#evergreen? with true value'
+    end
+
+    context 'when evergreenAssetFlag is nil' do
+      before { allow(asset).to receive(:evergreenAssetFlag) { nil } }
+
+      it_behaves_like 'asset#evergreen? with false value'
+    end
+
+    context 'when evergreenAssetFlag is boolean false' do
+      before { allow(asset).to receive(:evergreenAssetFlag) { false } }
+
+      it_behaves_like 'asset#evergreen? with false value'
+    end
+
+    context "when evergreenAssetFlag is string 'false'" do
+      before { allow(asset).to receive(:evergreenAssetFlag) { false } }
+
+      it_behaves_like 'asset#evergreen? with false value'
+    end
+
+  end
+
 end

--- a/spec/actv/asset_spec.rb
+++ b/spec/actv/asset_spec.rb
@@ -554,13 +554,13 @@ describe ACTV::Asset do
 
     shared_examples 'asset#evergreen? with true value' do
       it 'returns true' do
-        expect(asset.evergreen?).to eq true
+        expect(asset.evergreen?).to be_true
       end
     end
 
     shared_examples 'asset#evergreen? with false value' do
       it 'returns true' do
-        expect(asset.evergreen?).to eq false
+        expect(asset.evergreen?).to be_false
       end
     end
 

--- a/spec/actv/asset_status_spec.rb
+++ b/spec/actv/asset_status_spec.rb
@@ -21,4 +21,17 @@ describe ACTV::AssetStatus do
       (asset == other).should be_false
     end
   end
+
+
+  describe '#visible?' do
+    it 'returns true when status assetStatusId is 2' do
+      asset = ACTV::AssetStatus.new(assetStatusId: 2, assetStatusName: "VISIBLE")
+      expect(asset.visible?).to eq true
+    end
+
+    it 'returns false when status assetStatusId is not 2' do
+      asset = ACTV::AssetStatus.new(assetStatusId: 1, assetStatusName: "INVISIBLE")
+      expect(asset.visible?).to eq false
+    end
+  end
 end

--- a/spec/actv/asset_status_spec.rb
+++ b/spec/actv/asset_status_spec.rb
@@ -26,12 +26,12 @@ describe ACTV::AssetStatus do
   describe '#visible?' do
     it 'returns true when status assetStatusId is 2' do
       asset = ACTV::AssetStatus.new(assetStatusId: 2, assetStatusName: "VISIBLE")
-      expect(asset.visible?).to eq true
+      expect(asset.visible?).to be_true
     end
 
     it 'returns false when status assetStatusId is not 2' do
       asset = ACTV::AssetStatus.new(assetStatusId: 1, assetStatusName: "INVISIBLE")
-      expect(asset.visible?).to eq false
+      expect(asset.visible?).to be_false
     end
   end
 end

--- a/spec/actv/asset_status_spec.rb
+++ b/spec/actv/asset_status_spec.rb
@@ -24,8 +24,13 @@ describe ACTV::AssetStatus do
 
 
   describe '#visible?' do
-    it 'returns true when status assetStatusId is 2' do
+    it 'returns true when status assetStatusId is int 2' do
       asset = ACTV::AssetStatus.new(assetStatusId: 2, assetStatusName: "VISIBLE")
+      expect(asset.visible?).to be_true
+    end
+
+    it "returns true when status assetStatusId is string '2'" do
+      asset = ACTV::AssetStatus.new(assetStatusId: '2', assetStatusName: "VISIBLE")
       expect(asset.visible?).to be_true
     end
 

--- a/spec/actv/event_spec.rb
+++ b/spec/actv/event_spec.rb
@@ -312,24 +312,40 @@ describe ACTV::Event do
   describe '#disply_close_date' do
     context 'when tag is not set' do
       before do
-        subject.stub(:tag_by_description).with("displayclosedate").and_return nil
+        subject.stub(:tag_by_description).with('displayclosedate').and_return nil
       end
 
       its(:display_close_date?) { should eq true }
     end
 
     context 'when tag is set' do
-      context 'when true' do
+      context "when string 'true'" do
         before do
-          subject.stub(:tag_by_description).with("displayclosedate").and_return 'true'
+          subject.stub(:tag_by_description).with('displayclosedate').and_return 'true'
         end
 
         its(:display_close_date?) { should eq true }
       end
 
-      context 'when false' do
+      context 'when boolean true' do
         before do
-          subject.stub(:tag_by_description).with("displayclosedate").and_return 'false'
+          subject.stub(:tag_by_description).with('displayclosedate').and_return true
+        end
+
+        its(:display_close_date?) { should eq true }
+      end
+
+      context "when string 'false'" do
+        before do
+          subject.stub(:tag_by_description).with('displayclosedate').and_return 'false'
+        end
+
+        its(:display_close_date?) { should eq false }
+      end
+
+      context 'when boolean false' do
+        before do
+          subject.stub(:tag_by_description).with('displayclosedate').and_return false
         end
 
         its(:display_close_date?) { should eq false }


### PR DESCRIPTION
After ES upgrade, some of the filed type was changed from string to int. Correct the type at ACTV side.

A3 side: https://gitlab.dev.activenetwork.com/activenetwork/a3/merge_requests/42